### PR TITLE
Adding pagination buttons

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.port": 5501
+}

--- a/script.js
+++ b/script.js
@@ -1,47 +1,56 @@
-document.addEventListener('DOMContentLoaded', function () {
-  const searchButton = document.getElementById('searchButton');
-  const repositoriesContainer = document.getElementById('repositories');
-  const rateLimitMessage = document.getElementById('rateLimitMessage');
-  const tourButton = document.getElementById('tourButton');
+document.addEventListener("DOMContentLoaded", function () {
+  const searchButton = document.getElementById("searchButton");
+  const repositoriesContainer = document.getElementById("repositories");
+  const rateLimitMessage = document.getElementById("rateLimitMessage");
+  const tourButton = document.getElementById("tourButton");
 
-  const loader = document.querySelector('.loader');
-  const loadMoreButton = document.createElement('button');
-  loadMoreButton.textContent = 'Load More';
-  loadMoreButton.id = 'loadMoreButton';
-  loadMoreButton.style.display = 'none';
-  repositoriesContainer.after(loadMoreButton);
+  const loader = document.querySelector(".loader");
+
+  // Create a pagination
+  const paginationContainer = document.createElement("div");
+  paginationContainer.id = "paginationContainer";
+
+  // const loadMoreButton = document.createElement('button');
+  // loadMoreButton.textContent = 'Load More';
+  // loadMoreButton.id = 'loadMoreButton';
+  // loadMoreButton.style.display = 'none';
+  repositoriesContainer.after(paginationContainer);
 
   let currentPage = 1;
-  let currentQuery = '';
+  let currentQuery = "";
+  let totalPages = 1;
 
   startTour();
-  tourButton.addEventListener('click', startTour);
-  searchButton.addEventListener('click', fetchRepositories);
-  loadMoreButton.addEventListener('click', loadMoreRepositories);
+  tourButton.addEventListener("click", startTour);
+  searchButton.addEventListener("click", fetchRepositories);
+  // loadMoreButton.addEventListener("click", loadMoreRepositories);
 
   async function fetchRepositories(event, page = 1) {
     event.preventDefault();
 
-    const language = document.getElementById('customLanguage').value;
-    const topic = document.getElementById('topic').value;
+    // Remove any existing repositories from the previous search
+    repositoriesContainer.innerHTML = "";
 
-    const keyword = document.getElementById('keyword').value;
+    const language = document.getElementById("customLanguage").value;
+    const topic = document.getElementById("topic").value;
+
+    const keyword = document.getElementById("keyword").value;
 
     const sortOptions = Array.from(
       document.querySelectorAll('input[name="sort"]:checked')
     ).map((el) => el.value);
 
-    let query = 'https://api.github.com/search/repositories?q=';
+    let query = "https://api.github.com/search/repositories?q=";
     const filters = [];
 
     if (language) filters.push(`language:${language}`);
     if (topic) filters.push(`topic:${topic}`);
     if (keyword) filters.push(keyword);
 
-    query += filters.join('+');
+    query += filters.join("+");
 
     if (sortOptions.length > 0) {
-      query += `&sort=${sortOptions.join(',')}&order=desc`;
+      query += `&sort=${sortOptions.join(",")}&order=desc`;
     }
 
     query += `&page=${page}&per_page=10`;
@@ -53,61 +62,69 @@ document.addEventListener('DOMContentLoaded', function () {
     try {
       const response = await fetch(query);
       const data = await response.json();
-      const repositories = data.items;
+      if (data) {
+        const repositories = data.items;
 
-      // Getting the rate limit headers from response
-      const rateLimitRemain = response.headers.get('X-RateLimit-Remaining');
-      const rateLimitReset = response.headers.get('X-RateLimit-Reset');
-      const rateResetInSeconds = convertRateLimitResetToSeconds(rateLimitReset); // Convert the rate limit reset time to seconds
-      const rateLimitRemainInt = parseInt(rateLimitRemain); // Ensure that the rate limit is an integer, value returned is a string
+        // Because Github API only allows fetching up to 1000 results, we need to limit the total pages to 100
+        // https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28
+        totalPages = 100;
 
-      // Alert user if the rate limit is almost reached (< 5)
-      if (rateLimitRemainInt < 5) {
-        rateLimitMessage.innerHTML = `Reminder: You have ${rateLimitRemain} ${
-          rateLimitRemain > 1 ? 'requests' : 'request'
-        } left.`;
-      }
+        // Getting the rate limit headers from response
+        const rateLimitRemain = response.headers.get("X-RateLimit-Remaining");
+        const rateLimitReset = response.headers.get("X-RateLimit-Reset");
+        const rateResetInSeconds =
+          convertRateLimitResetToSeconds(rateLimitReset); // Convert the rate limit reset time to seconds
+        const rateLimitRemainInt = parseInt(rateLimitRemain); // Ensure that the rate limit is an integer, value returned is a string
 
-      // If the rate limit is 0 or exceeded, show an error message
-      if (rateLimitRemainInt === 0) {
-        throw new Error(
-          `Rate limit exceeded. Please try again after ${rateResetInSeconds} ${
-            rateResetInSeconds > 1 ? 'seconds' : 'second'
-          }.`
-        );
-      }
-
-      if (repositories.length === 0 && page === 1) {
-        repositoriesContainer.innerHTML = '<h2>No repositories found.</h2>';
-        loadMoreButton.style.display = 'none';
-      } else {
-        if (page === 1) {
-          repositoriesContainer.innerHTML = '';
+        // Alert user if the rate limit is almost reached (< 5)
+        if (rateLimitRemainInt < 5) {
+          rateLimitMessage.innerHTML = `Reminder: You have ${rateLimitRemain} ${
+            rateLimitRemain > 1 ? "requests" : "request"
+          } left.`;
         }
-        displayRepositories(repositories);
-        loadMoreButton.style.display =
-          repositories.length === 10 ? 'block' : 'none';
+
+        // If the rate limit is 0 or exceeded, show an error message
+        if (rateLimitRemainInt === 0) {
+          throw new Error(
+            `Rate limit exceeded. Please try again after ${rateResetInSeconds} ${
+              rateResetInSeconds > 1 ? "seconds" : "second"
+            }.`
+          );
+        }
+
+        if (repositories.length === 0 && page === 1) {
+          repositoriesContainer.innerHTML = "<h2>No repositories found.</h2>";
+          loadMoreButton.style.display = "none";
+        } else {
+          if (page === 1) {
+            repositoriesContainer.innerHTML = "";
+          }
+          displayRepositories(repositories);
+          renderPagination();
+          // loadMoreButton.style.display =
+          //   repositories.length === 10 ? "block" : "none";
+        }
       }
     } catch (error) {
-      console.error('Error fetching repositories:', error);
+      console.error("Error fetching repositories:", error);
       repositoriesContainer.innerHTML = `<h2>An error occurred while fetching repositories: ${error.message}</h2>`;
-      rateLimitMessage.innerHTML = '';
+      rateLimitMessage.innerHTML = "";
     } finally {
       hideLoader();
     }
   }
 
-  async function loadMoreRepositories() {
-    currentPage++;
-    await fetchRepositories({ preventDefault: () => {} }, currentPage);
-  }
+  // async function loadMoreRepositories() {
+  //   currentPage++;
+  //   await fetchRepositories({ preventDefault: () => {} }, currentPage);
+  // }
 
   function displayRepositories(repositories) {
     repositories.forEach((repo, index) => {
-      const repoCard = document.createElement('div');
-      repoCard.className = 'repository-card';
-      repoCard.style.opacity = '0';
-      repoCard.style.transform = 'translateY(20px)';
+      const repoCard = document.createElement("div");
+      repoCard.className = "repository-card";
+      repoCard.style.opacity = "0";
+      repoCard.style.transform = "translateY(20px)";
       repoCard.innerHTML = `
 
         <div class="flip-card-inner">
@@ -121,11 +138,11 @@ document.addEventListener('DOMContentLoaded', function () {
             <small>Language: ${repo.language}</small>
           </div>
           <div class="flip-card-back">
-            <p>${repo.description || 'No description available.'}</p>
+            <p>${repo.description || "No description available."}</p>
             <div class="details">
               <p>Owner: ${repo.owner.login}</p>
               <p>Open Issues: ${repo.open_issues_count}</p>
-              <p>Bio: ${repo.owner.bio || 'No bio available.'}</p>
+              <p>Bio: ${repo.owner.bio || "No bio available."}</p>
 
             </div>
           </div>
@@ -134,10 +151,97 @@ document.addEventListener('DOMContentLoaded', function () {
       repositoriesContainer.appendChild(repoCard);
 
       setTimeout(() => {
-        repoCard.style.opacity = '1';
-        repoCard.style.transform = 'translateY(0)';
+        repoCard.style.opacity = "1";
+        repoCard.style.transform = "translateY(0)";
       }, index * 100);
     });
+  }
+
+  function createButton(text, className, isDisabled, onClick) {
+    const button = document.createElement("button");
+    button.textContent = text;
+    if (isDisabled === true) {
+      className += " disabled";
+    }
+    button.className = className;
+    button.disabled = isDisabled;
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  function renderPagination() {
+    paginationContainer.innerHTML = "";
+
+    if (totalPages !== 1) {
+      // Create "Previous" button
+      const previousButton = createButton(
+        "Previous",
+        "pagination-button",
+        currentPage === 1,
+        () => {
+          if (currentPage > 1) {
+            currentPage--;
+            fetchRepositories({ preventDefault: () => {} }, currentPage);
+          }
+        }
+      );
+      paginationContainer.appendChild(previousButton);
+
+      const createPageButton = (page) => {
+        const pageButton = createButton(
+          page,
+          "pagination-button",
+          page === currentPage,
+          () => {
+            currentPage = page;
+            fetchRepositories({ preventDefault: () => {} }, currentPage);
+          }
+        );
+        paginationContainer.appendChild(pageButton);
+      };
+      createPageButton(1);
+
+      // Show ellipsis if there are more than 3 pages between the first page and the current page
+      if (currentPage > 4) {
+        const ellipsis = document.createElement("span");
+        ellipsis.textContent = "...";
+        paginationContainer.appendChild(ellipsis);
+      }
+
+      // Show a few pages around the current page
+      for (
+        let i = Math.max(2, currentPage - 2);
+        i <= Math.min(totalPages - 1, currentPage + 2);
+        i++
+      ) {
+        createPageButton(i);
+      }
+
+      // Show ellipsis if there are more than 3 pages between the current page and the last page
+      if (currentPage < totalPages - 3) {
+        const ellipsis = document.createElement("span");
+        ellipsis.textContent = "...";
+        paginationContainer.appendChild(ellipsis);
+      }
+
+      // Always show the last page
+      if (totalPages > 1) {
+        createPageButton(totalPages);
+      }
+
+      const nextButton = createButton(
+        "Next",
+        "pagination-button",
+        currentPage === totalPages,
+        () => {
+          if (currentPage < totalPages) {
+            currentPage++;
+            fetchRepositories({ preventDefault: () => {} }, currentPage);
+          }
+        }
+      );
+      paginationContainer.appendChild(nextButton);
+    }
   }
 
   function convertRateLimitResetToSeconds(rateLimitReset) {
@@ -151,17 +255,17 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   function showLoader() {
-    loader.style.display = 'inline-block';
-    repositoriesContainer.style.display = 'none';
+    loader.style.display = "inline-block";
+    repositoriesContainer.style.display = "none";
     searchButton.disabled = true;
-    searchButton.textContent = 'Searching...';
+    searchButton.textContent = "Searching...";
   }
 
   function hideLoader() {
-    loader.style.display = 'none';
-    repositoriesContainer.style.display = 'flex';
+    loader.style.display = "none";
+    repositoriesContainer.style.display = "flex";
     searchButton.disabled = false;
-    searchButton.textContent = 'Search';
+    searchButton.textContent = "Search";
   }
 
   function startTour() {
@@ -171,53 +275,53 @@ document.addEventListener('DOMContentLoaded', function () {
         cancelIcon: {
           enabled: true,
         },
-        classes: 'shadow-md bg-purple-dark',
-        scrollTo: { behavior: 'smooth', block: 'center' },
+        classes: "shadow-md bg-purple-dark",
+        scrollTo: { behavior: "smooth", block: "center" },
       },
     });
 
     tour.addStep({
-      id: 'language',
-      text: 'Select the programming language you are interested in.',
-      attachTo: { element: '#customLanguage', on: 'bottom' },
-      buttons: [{ text: 'Next', action: tour.next }],
+      id: "language",
+      text: "Select the programming language you are interested in.",
+      attachTo: { element: "#customLanguage", on: "bottom" },
+      buttons: [{ text: "Next", action: tour.next }],
     });
 
     tour.addStep({
-      id: 'topic',
-      text: 'Optionally enter a topic to narrow down your search.',
-      attachTo: { element: '#topic', on: 'bottom' },
-      buttons: [{ text: 'Next', action: tour.next }],
+      id: "topic",
+      text: "Optionally enter a topic to narrow down your search.",
+      attachTo: { element: "#topic", on: "bottom" },
+      buttons: [{ text: "Next", action: tour.next }],
     });
 
     tour.addStep({
-      id: 'keyword',
-      text: 'Optionally enter keyword to narrow down your search.',
-      attachTo: { element: '#keyword', on: 'bottom' },
-      buttons: [{ text: 'Next', action: tour.next }],
+      id: "keyword",
+      text: "Optionally enter keyword to narrow down your search.",
+      attachTo: { element: "#keyword", on: "bottom" },
+      buttons: [{ text: "Next", action: tour.next }],
     });
 
     tour.addStep({
-      id: 'sort',
-      text: 'Choose to Sort repositories by Commits, Issues, Pull Requests, Forks and Stars',
-      attachTo: { element: '#stars', on: 'bottom' },
-      buttons: [{ text: 'Next', action: tour.next }],
+      id: "sort",
+      text: "Choose to Sort repositories by Commits, Issues, Pull Requests, Forks and Stars",
+      attachTo: { element: "#stars", on: "bottom" },
+      buttons: [{ text: "Next", action: tour.next }],
     });
 
     tour.addStep({
-      id: 'search',
-      text: 'Click the Search button to fetch top repositories matching your criteria.',
-      attachTo: { element: '#searchButton', on: 'bottom' },
-      buttons: [{ text: 'Finish', action: tour.complete }],
+      id: "search",
+      text: "Click the Search button to fetch top repositories matching your criteria.",
+      attachTo: { element: "#searchButton", on: "bottom" },
+      buttons: [{ text: "Finish", action: tour.complete }],
     });
 
     tour.start();
   }
 
   document
-    .getElementById('myForm')
-    .addEventListener('submit', function (event) {
+    .getElementById("myForm")
+    .addEventListener("submit", function (event) {
       event.preventDefault();
-      console.log('Form submission prevented!');
+      console.log("Form submission prevented!");
     });
 });

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@ body {
   -ms-overflow-style: none;
   overflow-y: scroll;
   /* Ensure vertical scrollbar doesn't appear on content overflow */
-  font-family: 'Roboto', sans-serif;
+  font-family: "Roboto", sans-serif;
   margin: 0;
   padding: 0;
   background-color: #f5f7fa;
@@ -172,7 +172,7 @@ body {
   margin-top: 20px;
 }
 
-.controls input[type='radio'] {
+.controls input[type="radio"] {
   margin-bottom: 10px;
 }
 
@@ -288,6 +288,37 @@ body {
   color: #5800ef;
   transform: rotateY(180deg);
   text-align: left;
+}
+
+/* Pagination */
+
+#paginationContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 30px;
+}
+.pagination-button {
+  display: block;
+  font-size: 20px;
+  margin-left: 4px;
+  margin-right: 4px;
+  border-radius: 5px;
+  border: 1px solid #ccc;
+  color: #5800ef;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  padding: 10px;
+  font-weight: bold;
+}
+.pagination-button:hover {
+  background-color: #e0e0e0;
+}
+
+.pagination-button:disabled {
+  cursor: not-allowed;
+  background-color: rgb(224, 205, 205);
+  color: gray;
 }
 
 /* Footer */
@@ -449,7 +480,7 @@ footer.footer {
 }
 
 .switch::before {
-  content: '';
+  content: "";
   position: absolute;
   height: 18px;
   width: 18px;
@@ -542,7 +573,7 @@ body.dark-mode a {
 }
 
 .loader::after {
-  content: '';
+  content: "";
   box-sizing: border-box;
   position: absolute;
   left: 0;


### PR DESCRIPTION
Fixes #2:
## New Feature:
Currently, there is only 1 button to navigate between each page with 10 repositories shown. I want to implement a pagination buttons that will have more buttons as "Previous", "Next", "Page Buttons". That will be easy for users to navigate to the specific page that they are interest.

## Implementation:
Because of the limit search from GitHub API that only allows us to fetch up to 1000 results, so even when the search has more than that amount, and if we want to access to the last page, then it will return an error telling that the returned results are undefined. So because your current design wants to show 10 repos per page, then I will set a fixed amount for page as [100](https://github.com/jaiyankargupta/GitExplorer/pull/19/files#diff-ed3ee7e0beea2498ff3b8ca85973d122fc6fa3d585d62b5807ec034d0cf076b3R68-R70):

I added a new `div` for pagination section in your `script.js` so that I can have some CSS to make it pretty a bit

The main logic will be 2 new functions: `createButton()` and `renderPagination()`

For CSS, I had some design when it's hovered for current page as well as other page. For the current page, user cannot click to it and it will be disabled.